### PR TITLE
Feature: Implement RDP client connection info data source with acceptance tests

### DIFF
--- a/docs/API_IMPLEMENTATION_STATUS.md
+++ b/docs/API_IMPLEMENTATION_STATUS.md
@@ -91,7 +91,7 @@ These APIs are officially documented in the Kasm API documentation.
 #### RDP Client Connection
 | API Endpoint | Implementation Status | Resource Name | File Location | Tests | Test File |
 |--------------|---------------------|---------------|---------------|-------|-----------|
-| POST /api/public/get_rdp_client_connection_info | Not Implemented | - | - | ❌ | - |
+| POST /api/public/get_rdp_client_connection_info | Implemented | kasm_rdp_client_connection_info | internal/datasources/rdp | ✅ | internal/datasources/rdp/tests/datasource_test.go |
 
 #### Egress Management
 | API Endpoint | Implementation Status | Resource Name | File Location | Tests | Test File |
@@ -168,6 +168,11 @@ These APIs are officially documented in the Kasm API documentation.
 | DELETE /api/public/delete_group_membership | Implemented | kasm_group_membership | internal/resources/group_membership | ✅ | internal/resources/group_membership/tests/group_membership_test.go |
 | POST /api/public/get_group_memberships | Implemented | kasm_group_memberships | internal/datasources/group_memberships | ✅ | internal/resources/group_membership/tests/group_membership_test.go |
 
+#### RDP Client Connection
+| API Endpoint | Implementation Status | Data Source Name | File Location | Tests | Test File |
+|--------------|---------------------|------------------|---------------|-------|-----------|
+| POST /api/public/get_rdp_client_connection_info | Implemented | kasm_rdp_client_connection_info | internal/datasources/rdp | ✅ | internal/datasources/rdp/tests/datasource_test.go |
+
 ## Undocumented APIs
 
 These APIs are not officially documented in the Kasm API documentation but are used by the Kasm web UI.
@@ -205,7 +210,6 @@ These APIs are not officially documented in the Kasm API documentation but are u
 1. Session Features:
    - POST /api/public/screenshot (for kasm_screenshot) - Client implementation exists
    - POST /api/public/exec_command (for kasm_exec) - Client implementation exists
-   - POST /api/public/get_rdp_client_connection_info (for kasm_rdp) - Client implementation exists
 
 ### Additional Undocumented Resources Found
 1. Login Management:

--- a/docs/data-sources/rdp_client_connection_info.md
+++ b/docs/data-sources/rdp_client_connection_info.md
@@ -1,0 +1,56 @@
+# RDP Client Connection Info Data Source
+
+Retrieves RDP client connection information for a Kasm session.
+
+> **Note:** This functionality requires a Windows RDP server configured in Kasm. For container-based sessions, the RDP connection info will be empty. See the [Kasm documentation on Fixed Infrastructure](https://kasmweb.com/docs/latest/how_to/fixed_infrastructure.html#fixed-infrastructure-rdp-vnc-ssh-kasmvnc) for more details on setting up RDP servers.
+
+## Example Usage
+
+### Basic Usage
+```hcl
+data "kasm_rdp_client_connection_info" "example_file" {
+  user_id = "44edb3e5-2909-4927-a60b-6e09c7219104"
+  kasm_id = "898813d7-a677-4c60-8999-c9ea346a3e21"
+  connection_type = "file"
+}
+
+output "rdp_file" {
+  value = data.kasm_rdp_client_connection_info.example_file.file
+}
+
+data "kasm_rdp_client_connection_info" "example_url" {
+  user_id = "44edb3e5-2909-4927-a60b-6e09c7219104"
+  kasm_id = "898813d7-a677-4c60-8999-c9ea346a3e21"
+  connection_type = "url"
+}
+
+output "rdp_url" {
+  value = data.kasm_rdp_client_connection_info.example_url.url
+}
+```
+
+### Advanced Usage
+```hcl
+data "kasm_rdp_client_connection_info" "custom" {
+  user_id         = kasm_user.example.id
+  kasm_id         = kasm_session.example.id
+  connection_type = "file"
+}
+
+output "rdp_file" {
+  value     = data.kasm_rdp_client_connection_info.custom.file
+  sensitive = true
+}
+```
+
+## Argument Reference
+
+* `user_id` - (Required) The ID of the user requesting the connection.
+* `kasm_id` - (Required) The ID of the Kasm session.
+* `connection_type` - (Optional) The type of connection to retrieve ("url" or "file"). Defaults to "url".
+
+## Attribute Reference
+
+* `id` - The unique identifier for the connection info.
+* `file` - The RDP connection file content (if connection_type is "file").
+* `url` - The URL for RDP access (if connection_type is "url").

--- a/internal/datasources/rdp/datasource.go
+++ b/internal/datasources/rdp/datasource.go
@@ -1,0 +1,138 @@
+package rdp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+
+	"terraform-provider-kasm/internal/client"
+	"terraform-provider-kasm/internal/validators"
+)
+
+// Ensure the implementation satisfies the expected interfaces.
+var (
+	_ datasource.DataSource = &rdpClientConnectionInfoDataSource{}
+)
+
+// NewRDPClientConnectionInfoDataSource is a helper function to simplify the provider implementation.
+func NewRDPClientConnectionInfoDataSource() datasource.DataSource {
+	return &rdpClientConnectionInfoDataSource{
+		client: &client.Client{},
+	}
+}
+
+// rdpClientConnectionInfoDataSource is the data source implementation.
+type rdpClientConnectionInfoDataSource struct {
+	client *client.Client
+}
+
+// Metadata returns the data source type name.
+func (d *rdpClientConnectionInfoDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_rdp_client_connection_info"
+}
+
+// Schema defines the schema for the data source.
+func (d *rdpClientConnectionInfoDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Description: "Retrieves RDP client connection information for a Kasm session.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed:    true,
+				Description: "Identifier of the RDP client connection info.",
+			},
+			"user_id": schema.StringAttribute{
+				Required:    true,
+				Description: "The ID of the user for which to retrieve the RDP connection info.",
+			},
+			"kasm_id": schema.StringAttribute{
+				Required:    true,
+				Description: "The ID of the Kasm session for which to retrieve the RDP connection info.",
+			},
+			"connection_type": schema.StringAttribute{
+				Optional:    true,
+				Description: "Type of connection to retrieve (url or file)",
+				Validators: []validator.String{
+					validators.StringOneOf("url", "file"),
+				},
+			},
+			"file": schema.StringAttribute{
+				Computed:    true,
+				Description: "The RDP file content (if connection_type is 'file' or not specified).",
+			},
+			"url": schema.StringAttribute{
+				Computed:    true,
+				Description: "The RDP URL (if connection_type is 'url').",
+			},
+		},
+	}
+}
+
+// Configure adds the provider configured client to the data source.
+func (d *rdpClientConnectionInfoDataSource) Configure(_ context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*client.Client)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Data Source Configure Type",
+			fmt.Sprintf("Expected *client.Client, got: %T. Please report this issue to the provider developers.", req.ProviderData),
+		)
+		return
+	}
+
+	d.client = client
+}
+
+// Read refreshes the Terraform state with the latest data.
+func (d *rdpClientConnectionInfoDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var state rdpClientConnectionInfoModel
+
+	// Read Terraform configuration data into the model
+	resp.Diagnostics.Append(req.Config.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Get the connection info from the API
+	connectionType := client.RDPConnectionTypeFile
+	if !state.ConnectionType.IsNull() && state.ConnectionType.ValueString() == "url" {
+		connectionType = client.RDPConnectionTypeURL
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Getting RDP connection info for user %s, kasm %s, type %s", state.UserID.ValueString(), state.KasmID.ValueString(), connectionType))
+	connectionInfo, err := d.client.GetRDPConnectionInfo(state.UserID.ValueString(), state.KasmID.ValueString(), connectionType)
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Error getting RDP connection info",
+			fmt.Sprintf("Could not get RDP connection info: %v", err),
+		)
+		return
+	}
+
+	// Set the ID
+	state.ID = types.StringValue(fmt.Sprintf("%s-%s-%s", state.UserID.ValueString(), state.KasmID.ValueString(), connectionType))
+
+	// Set the connection info
+	state.File = types.StringValue(connectionInfo.File)
+	state.URL = types.StringValue(connectionInfo.URL)
+
+	// Save the data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+// rdpClientConnectionInfoModel maps the data source schema data.
+type rdpClientConnectionInfoModel struct {
+	ID             types.String `tfsdk:"id"`
+	UserID         types.String `tfsdk:"user_id"`
+	KasmID         types.String `tfsdk:"kasm_id"`
+	ConnectionType types.String `tfsdk:"connection_type"`
+	File           types.String `tfsdk:"file"`
+	URL            types.String `tfsdk:"url"`
+}

--- a/internal/datasources/rdp/tests/datasource_acc_test.go
+++ b/internal/datasources/rdp/tests/datasource_acc_test.go
@@ -1,0 +1,333 @@
+//go:build acceptance
+// +build acceptance
+
+package tests
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"terraform-provider-kasm/internal/client"
+	"terraform-provider-kasm/testutils"
+)
+
+var createdImageID string // Track the created image ID for cleanup
+
+// cleanupTestImage deletes the test image if it was created
+func cleanupTestImage(t *testing.T, c *client.Client) {
+	if createdImageID != "" {
+		if err := c.DeleteImage(createdImageID); err != nil {
+			t.Logf("Warning: Failed to delete test image %s: %v", createdImageID, err)
+		} else {
+			log.Printf("[DEBUG] Successfully deleted test image: %s", createdImageID)
+			createdImageID = "" // Reset after successful deletion
+		}
+	}
+}
+
+// ensureWorkspaceImage ensures a test image exists and returns its ID
+func ensureWorkspaceImage(t *testing.T, c *client.Client) string {
+	log.Printf("[DEBUG] Starting ensureWorkspaceImage")
+
+	// If we already created an image in this test run, return its ID
+	if createdImageID != "" {
+		return createdImageID
+	}
+
+	// Try to find an existing image first
+	images, err := c.GetImages()
+	if err != nil {
+		log.Printf("[DEBUG] Error getting images: %v", err)
+		log.Printf("[DEBUG] Will attempt to create new image")
+	} else {
+		log.Printf("[DEBUG] Found %d existing images", len(images))
+		for i, img := range images {
+			log.Printf("[DEBUG] Image %d: ID=%s Name=%s Available=%v", i, img.ImageID, img.Name, img.Available)
+		}
+		// Look for any usable image
+		for _, img := range images {
+			if img.ImageID != "" && img.Available {
+				log.Printf("[DEBUG] Found existing usable image: %s (%s)", img.Name, img.ImageID)
+				return img.ImageID
+			}
+		}
+		log.Printf("[DEBUG] No usable image found, will create new one")
+	}
+
+	// Create a small, lightweight image for testing
+	runConfig := map[string]interface{}{
+		"hostname":       "kasm-test",
+		"container_name": "kasm_test_container",
+		"network":        "kasm-network",
+		"environment": map[string]string{
+			"KASM_TEST": "true",
+		},
+	}
+	runConfigJSON, _ := json.Marshal(runConfig)
+
+	execConfig := map[string]interface{}{}
+	execConfigJSON, _ := json.Marshal(execConfig)
+
+	volumeMappings := map[string]interface{}{}
+	volumeMappingsJSON, _ := json.Marshal(volumeMappings)
+
+	// Using a small image for faster download
+	image := &client.CreateImageRequest{
+		ImageSrc:           "img/thumbnails/filezilla.png",
+		Categories:         "Testing",
+		RunConfig:          string(runConfigJSON),
+		Description:        "Test image for RDP connection tests",
+		FriendlyName:       "FileZilla_Test",
+		DockerRegistry:     "https://index.docker.io/v1/",
+		Name:               "kasmweb/filezilla:1.16.1",
+		UncompressedSizeMB: 1000,
+		ImageType:          "Container",
+		Enabled:            true,
+		Memory:             1024000000,
+		Cores:              1,
+		GPUCount:           0,
+		RequireGPU:         nil,
+		ExecConfig:         string(execConfigJSON),
+		VolumeMappings:     string(volumeMappingsJSON),
+	}
+
+	log.Printf("[DEBUG] Creating test image with config: %+v", image)
+
+	var createdImage *client.Image
+	var lastErr error
+	maxRetries := 3
+	for i := 0; i < maxRetries; i++ {
+		log.Printf("[DEBUG] Attempt %d/%d to create image", i+1, maxRetries)
+
+		createdImage, lastErr = c.AddWorkspaceImage(image)
+
+		if lastErr != nil {
+			log.Printf("[DEBUG] Attempt %d failed with error: %v", i+1, lastErr)
+			if i < maxRetries-1 {
+				sleepDuration := time.Second * time.Duration(i+1)
+				log.Printf("[DEBUG] Waiting %v before next attempt", sleepDuration)
+				time.Sleep(sleepDuration)
+			}
+			continue
+		}
+
+		if createdImage == nil {
+			lastErr = fmt.Errorf("API returned success but image is nil")
+			log.Printf("[DEBUG] Attempt %d failed: %v", i+1, lastErr)
+			if i < maxRetries-1 {
+				time.Sleep(time.Second * time.Duration(i+1))
+			}
+			continue
+		}
+
+		if createdImage.ImageID == "" {
+			lastErr = fmt.Errorf("API returned image but ImageID is empty")
+			log.Printf("[DEBUG] Attempt %d failed: %v", i+1, lastErr)
+			if i < maxRetries-1 {
+				time.Sleep(time.Second * time.Duration(i+1))
+			}
+			continue
+		}
+
+		// Success! Store the ID for cleanup
+		createdImageID = createdImage.ImageID
+		log.Printf("[DEBUG] Successfully created test image with ID: %s", createdImageID)
+		log.Printf("[DEBUG] Image details: %+v", createdImage)
+
+		// Wait for the image to be downloaded and available
+		log.Printf("[DEBUG] Waiting for image to be downloaded and available...")
+		waitForImageAvailable(t, c, createdImageID)
+
+		return createdImageID
+	}
+
+	errorMsg := fmt.Sprintf("Failed to create workspace image after %d attempts. Last error: %v", maxRetries, lastErr)
+	log.Printf("[DEBUG] %s", errorMsg)
+	t.Fatal(errorMsg)
+	return "" // unreachable
+}
+
+// waitForImageAvailable waits for an image to be downloaded and available
+func waitForImageAvailable(t *testing.T, c *client.Client, imageID string) {
+	maxRetries := 30
+	retryInterval := 10 * time.Second
+
+	for i := 0; i < maxRetries; i++ {
+		images, err := c.GetImages()
+		if err != nil {
+			log.Printf("[DEBUG] Error getting images: %v", err)
+		} else {
+			for _, img := range images {
+				if img.ImageID == imageID {
+					if img.Available {
+						log.Printf("[DEBUG] Image %s is now available", imageID)
+						return
+					}
+					log.Printf("[DEBUG] Image %s is not yet available, status: %v", imageID, img.Available)
+					break
+				}
+			}
+		}
+
+		log.Printf("[DEBUG] Waiting for image to be available, attempt %d/%d. Sleeping for %v...", i+1, maxRetries, retryInterval)
+		time.Sleep(retryInterval)
+	}
+
+	log.Printf("[WARN] Image %s did not become available after %d attempts", imageID, maxRetries)
+}
+
+// TestAccKasmRDPClientConnectionInfo tests the RDP client connection info data source
+func TestAccKasmRDPClientConnectionInfo(t *testing.T) {
+	// Skip the test if TF_ACC is not set
+	testutils.TestAccPreCheck(t)
+
+	// Get the user ID from the environment or use a default
+	userID := os.Getenv("KASM_USER_ID")
+	if userID == "" {
+		userID = "44edb3e5-2909-4927-a60b-6e09c7219104"
+	}
+	log.Printf("[DEBUG] Using user ID: %s", userID)
+
+	// Create a new Kasm client
+	c := client.NewClient(
+		os.Getenv("KASM_BASE_URL"),
+		os.Getenv("KASM_API_KEY"),
+		os.Getenv("KASM_API_SECRET"),
+		true, // insecure - ignore TLS certificate verification
+	)
+
+	// Ensure we have a usable image
+	imageID := ensureWorkspaceImage(t, c)
+	log.Printf("[DEBUG] Using image ID: %s", imageID)
+
+	// Ensure the test image is cleaned up after the test
+	defer cleanupTestImage(t, c)
+
+	// Create a new Kasm session
+	log.Printf("[DEBUG] Creating Kasm session for user %s with image %s", userID, imageID)
+	sessionToken := uuid.New().String()
+	kasm, err := c.CreateKasm(userID, imageID, sessionToken, "test", true, false, false, false)
+	if err != nil {
+		t.Fatalf("Failed to create Kasm session: %v", err)
+	}
+
+	// Ensure the Kasm session is deleted when the test is done
+	defer func() {
+		log.Printf("[DEBUG] Cleaning up Kasm session %s", kasm.KasmID)
+		err := c.DestroyKasm(userID, kasm.KasmID)
+		if err != nil {
+			log.Printf("[WARN] Failed to delete Kasm session: %v", err)
+		}
+	}()
+
+	// Get session details
+	log.Printf("[DEBUG] Getting session details for Kasm ID: %s", kasm.KasmID)
+
+	// Wait for the session to be ready before requesting RDP connection info
+	log.Printf("[DEBUG] Waiting for session to be ready...")
+	maxRetries := 30
+	retryInterval := 5 * time.Second
+	var sessionReady bool
+	var sessionDetails *client.KasmStatusResponse
+
+	for i := 0; i < maxRetries; i++ {
+		var err error
+		sessionDetails, err = c.GetKasmStatus(userID, kasm.KasmID, true)
+		if err != nil {
+			log.Printf("[DEBUG] Error getting session status: %v. Retrying...", err)
+		} else {
+			log.Printf("[DEBUG] Session details: %+v", sessionDetails)
+			if sessionDetails.Kasm != nil && sessionDetails.Kasm.OperationalStatus == "running" {
+				log.Printf("[DEBUG] Session is ready (running)")
+				sessionReady = true
+				break
+			}
+			log.Printf("[DEBUG] Session is not ready yet, status: %s", sessionDetails.OperationalStatus)
+		}
+
+		log.Printf("[DEBUG] Waiting for session to be ready, attempt %d/%d. Sleeping for %v...", i+1, maxRetries, retryInterval)
+		time.Sleep(retryInterval)
+	}
+
+	if !sessionReady {
+		t.Fatalf("Session did not become ready after %d attempts", maxRetries)
+	}
+
+	// Test RDP connection info for file type
+	log.Printf("[DEBUG] Getting RDP connection info for file type")
+	fileConnectionInfo, err := c.GetRDPConnectionInfo(userID, kasm.KasmID, "file")
+	if err != nil {
+		t.Fatalf("Failed to get RDP connection info for file type: %v", err)
+	}
+	log.Printf("[DEBUG] RDP file connection info: %+v", fileConnectionInfo)
+	if fileConnectionInfo.File == "" {
+		log.Printf("[WARN] RDP file connection info is empty. This is expected when using container images instead of RDP servers.")
+		log.Printf("[INFO] To fully test RDP functionality, additional infrastructure is required (Windows RDP server configured in Kasm).")
+	}
+
+	// Test RDP connection info for URL type
+	log.Printf("[DEBUG] Getting RDP connection info for URL type")
+	urlConnectionInfo, err := c.GetRDPConnectionInfo(userID, kasm.KasmID, "url")
+	if err != nil {
+		t.Fatalf("Failed to get RDP connection info for URL type: %v", err)
+	}
+	log.Printf("[DEBUG] RDP URL connection info: %+v", urlConnectionInfo)
+	if urlConnectionInfo.URL == "" {
+		log.Printf("[WARN] RDP URL connection info is empty. This is expected when using container images instead of RDP servers.")
+		log.Printf("[INFO] To fully test RDP functionality, additional infrastructure is required (Windows RDP server configured in Kasm).")
+	}
+
+	// Run the Terraform acceptance test
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testutils.TestAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccKasmRDPClientConnectionInfoFileConfig(userID, kasm.KasmID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.kasm_rdp_client_connection_info.test_file", "id"),
+					resource.TestCheckResourceAttr("data.kasm_rdp_client_connection_info.test_file", "user_id", userID),
+					resource.TestCheckResourceAttr("data.kasm_rdp_client_connection_info.test_file", "kasm_id", kasm.KasmID),
+					resource.TestCheckResourceAttr("data.kasm_rdp_client_connection_info.test_file", "connection_type", "file"),
+					// We don't check for file content since it might be empty with container images
+				),
+			},
+			{
+				Config: testAccKasmRDPClientConnectionInfoURLConfig(userID, kasm.KasmID),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("data.kasm_rdp_client_connection_info.test_url", "id"),
+					resource.TestCheckResourceAttr("data.kasm_rdp_client_connection_info.test_url", "user_id", userID),
+					resource.TestCheckResourceAttr("data.kasm_rdp_client_connection_info.test_url", "kasm_id", kasm.KasmID),
+					resource.TestCheckResourceAttr("data.kasm_rdp_client_connection_info.test_url", "connection_type", "url"),
+					// We don't check for URL content since it might be empty with container images
+				),
+			},
+		},
+	})
+}
+
+// Test configurations
+func testAccKasmRDPClientConnectionInfoFileConfig(userID, kasmID string) string {
+	return testutils.ProviderConfig() + fmt.Sprintf(`
+data "kasm_rdp_client_connection_info" "test_file" {
+  user_id = "%s"
+  kasm_id = "%s"
+  connection_type = "file"
+}
+`, userID, kasmID)
+}
+
+func testAccKasmRDPClientConnectionInfoURLConfig(userID, kasmID string) string {
+	return testutils.ProviderConfig() + fmt.Sprintf(`
+data "kasm_rdp_client_connection_info" "test_url" {
+  user_id = "%s"
+  kasm_id = "%s"
+  connection_type = "url"
+}
+`, userID, kasmID)
+}

--- a/internal/datasources/rdp/tests/datasource_test.go
+++ b/internal/datasources/rdp/tests/datasource_test.go
@@ -1,0 +1,80 @@
+//go:build unit
+// +build unit
+
+package tests
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/stretchr/testify/assert"
+	"terraform-provider-kasm/internal/datasources/rdp"
+)
+
+// Test the data source schema
+func TestRDPClientConnectionInfoDataSource_Schema(t *testing.T) {
+	t.Parallel()
+
+	// Create the data source
+	ds := rdp.NewRDPClientConnectionInfoDataSource()
+
+	// Verify it implements the expected interface
+	_, ok := ds.(datasource.DataSource)
+	assert.True(t, ok, "Data source doesn't implement datasource.DataSource")
+}
+
+// Test the data source metadata
+func TestRDPClientConnectionInfoDataSource_Metadata(t *testing.T) {
+	t.Parallel()
+
+	// Create the data source
+	ds := rdp.NewRDPClientConnectionInfoDataSource()
+
+	// Get the data source as the correct interface
+	dataSource, ok := ds.(datasource.DataSource)
+	assert.True(t, ok, "Data source doesn't implement datasource.DataSource")
+
+	// Create a metadata request and response
+	req := datasource.MetadataRequest{
+		ProviderTypeName: "kasm",
+	}
+	resp := &datasource.MetadataResponse{}
+
+	// Call the Metadata method
+	dataSource.Metadata(context.Background(), req, resp)
+
+	// Verify the type name
+	assert.Equal(t, "kasm_rdp_client_connection_info", resp.TypeName, "Unexpected type name")
+}
+
+// Test the data source schema method
+func TestRDPClientConnectionInfoDataSource_SchemaMethod(t *testing.T) {
+	t.Parallel()
+
+	// Create the data source
+	ds := rdp.NewRDPClientConnectionInfoDataSource()
+
+	// Get the data source as the correct interface
+	dataSource, ok := ds.(datasource.DataSource)
+	assert.True(t, ok, "Data source doesn't implement datasource.DataSource")
+
+	// Create a schema request and response
+	req := datasource.SchemaRequest{}
+	resp := &datasource.SchemaResponse{}
+
+	// Call the Schema method
+	dataSource.Schema(context.Background(), req, resp)
+
+	// Verify schema attributes
+	assert.NotNil(t, resp.Schema, "Schema should not be nil")
+	assert.NotEmpty(t, resp.Schema.Description, "Schema should have a description")
+
+	// Check required attributes
+	assert.Contains(t, resp.Schema.Attributes, "id", "Schema should have id attribute")
+	assert.Contains(t, resp.Schema.Attributes, "user_id", "Schema should have user_id attribute")
+	assert.Contains(t, resp.Schema.Attributes, "kasm_id", "Schema should have kasm_id attribute")
+	assert.Contains(t, resp.Schema.Attributes, "connection_type", "Schema should have connection_type attribute")
+	assert.Contains(t, resp.Schema.Attributes, "file", "Schema should have file attribute")
+	assert.Contains(t, resp.Schema.Attributes, "url", "Schema should have url attribute")
+}

--- a/internal/validators/validators.go
+++ b/internal/validators/validators.go
@@ -36,6 +36,23 @@ func (v StringValidator) ValidateString(ctx context.Context, req validator.Strin
 	}
 }
 
+// StringOneOf returns a validator which ensures that any configured string
+// value matches one of the given values exactly.
+func StringOneOf(validValues ...string) validator.String {
+	return StringValidator{
+		Desc: fmt.Sprintf("value must be one of: %v", validValues),
+		ValidateFn: func(value string) bool {
+			for _, validValue := range validValues {
+				if value == validValue {
+					return true
+				}
+			}
+			return false
+		},
+		ErrMessage: fmt.Sprintf("value must be one of: %v", validValues),
+	}
+}
+
 // Int64Validator is a custom int64 validator
 type Int64Validator struct {
 	Desc       string

--- a/main.go
+++ b/main.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"log"
 
+	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
-	"terraform-provider-kasm/internal/provider"
+	kasmProvider "terraform-provider-kasm/internal/provider"
 )
 
 func main() {
-	err := providerserver.Serve(context.Background(), provider.New, providerserver.ServeOpts{
+	err := providerserver.Serve(context.Background(), func() provider.Provider {
+		return kasmProvider.New()
+	}, providerserver.ServeOpts{
 		Address: "registry.terraform.io/hashicorp/kasm",
 	})
 	if err != nil {


### PR DESCRIPTION
**Changes**

- New Data Source: Added kasm_rdp_client_connection_info data source that retrieves RDP connection information for a specified Kasm session
- Tests: Implemented both unit tests and acceptance tests for the data source
- API Implementation Status: Updated the API implementation status document to reflect the new data source

**Implementation Details**

- The data source supports two connection types: file and url
- Added appropriate validation for input parameters
- Implemented proper error handling for API responses
- Added documentation explaining that RDP functionality requires a Windows RDP server configured in Kasm
- Enhanced acceptance tests to handle empty responses gracefully when testing with container-based sessions

**Documentation**

- Added a new documentation file for the data source: docs/data-sources/rdp_client_connection_info.md
- Included a note explaining that RDP functionality requires a Windows RDP server
- Provided comprehensive examples showing how to use both connection types
- Updated the API implementation status document